### PR TITLE
Dependency bump to support recent Crystal version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+jobs:
+  Tests:
+    runs-on: ubuntu-latest
+    # env:
+    #   STORE: memory
+
+    services:
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
+
+    steps:
+      - name: Download source
+        uses: actions/checkout@v3
+
+      - name: Install Crystal
+        uses: crystal-lang/install-crystal@v1
+
+      - name: Cache shards
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/shards
+          key: shards-${{ hashFiles('shard.yml') }}
+          restore-keys: ${{ runner.os }}-shards-
+
+      - name: Install shards
+        run: shards update
+
+      - name: Run tests
+        run: crystal spec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,11 @@ on:
 jobs:
   Tests:
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        store: ["memory", "redis"]
+
     # env:
     #   STORE: memory
 
@@ -35,3 +40,5 @@ jobs:
 
       - name: Run tests
         run: crystal spec
+        env:
+          STORE: ${{ matrix.store }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,6 @@ jobs:
       matrix:
         store: ["memory", "redis"]
 
-    # env:
-    #   STORE: memory
-
     services:
       redis:
         image: redis

--- a/shard.lock
+++ b/shard.lock
@@ -2,13 +2,13 @@ version: 2.0
 shards:
   ameba:
     git: https://github.com/crystal-ameba/ameba.git
-    version: 0.14.3
+    version: 1.5.0
 
-  pool:
-    git: https://github.com/ysbaddaden/pool.git
-    version: 0.2.4
+  db:
+    git: https://github.com/crystal-lang/crystal-db.git
+    version: 0.12.0
 
   redis:
-    git: https://github.com/stefanwille/crystal-redis.git
-    version: 2.7.0
+    git: https://github.com/jgaskins/redis.git
+    version: 0.8.0
 

--- a/shard.yml
+++ b/shard.yml
@@ -5,14 +5,14 @@ authors:
   - Florin Lipan <florinlipan@gmail.com>
   - Rodrigo Pinto <contato@rodrigopinto.me>
 
-crystal: ">= 0.35.1, < 2.0.0"
+crystal: "1.0.0, < 2.0.0"
 
 dependencies:
   redis:
-    github: stefanwille/crystal-redis
-    version: ~> 2.7.0
+    github: jgaskins/redis
+    version: ~> 0.8.0
 
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 0.14.3
+    version: ~> 1.5.0

--- a/src/defense.cr
+++ b/src/defense.cr
@@ -37,7 +37,7 @@ module Defense
   end
 
   def self.store : Store
-    @@store ||= RedisStore.new(url: ENV["REDIS_URL"]?)
+    @@store ||= RedisStore.new
   end
 
   def self.store=(store : Store)

--- a/src/defense/handler.cr
+++ b/src/defense/handler.cr
@@ -7,15 +7,15 @@ module Defense
     def initialize
     end
 
-    def call(ctx : HTTP::Server::Context)
-      if Defense.safelisted?(ctx.request)
-        call_next(ctx)
-      elsif Defense.blocklisted?(ctx.request)
-        Defense.blocklisted_response.call(ctx.response)
-      elsif Defense.throttled?(ctx.request)
-        Defense.throttled_response.call(ctx.response)
+    def call(context : HTTP::Server::Context)
+      if Defense.safelisted?(context.request)
+        call_next(context)
+      elsif Defense.blocklisted?(context.request)
+        Defense.blocklisted_response.call(context.response)
+      elsif Defense.throttled?(context.request)
+        Defense.throttled_response.call(context.response)
       else
-        call_next(ctx)
+        call_next(context)
       end
     end
   end


### PR DESCRIPTION
Hey 👋🏼 

This PR has a few things I did to make the shard compatible with Crystal `1.10.x`

- Bump dependencies and fix a couple small warnings
- Replace Redis shard with `jgaskins/redis`
   - I ran into compilation issues even upgrading to latest release (something related to connection pools)
   - Largely popular shards (i.e. [`mosquito-cr/mosquito`](https://github.com/mosquito-cr/mosquito/blob/master/shard.yml)) replaced it as well and I believe they conflict with one another
- Replace Travis with GitHub Actions for CI

There were no Redis/Memory store specs but I tested this locally with my own project and works nicely for me 🙂 